### PR TITLE
fix: Swagger 테스트 시 httpBasic 인증 팝업 제거

### DIFF
--- a/src/main/java/com/example/hackathon/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/hackathon/global/config/SecurityConfig.java
@@ -45,10 +45,10 @@ public class SecurityConfig {
                                 "/docs/**"
                         ).permitAll()
                         .anyRequest().authenticated()
-                )
+                );
 
                 // ✅ 기타 설정 (필요 시 추가)
-                .httpBasic(Customizer.withDefaults());
+                //.httpBasic(Customizer.withDefaults());
 
         // ✅ JWT 인증 필터 적용
         http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);


### PR DESCRIPTION
- Spring Security 설정에서 .httpBasic() 제거
- 기본 인증 팝업 대신 401 JSON 응답 처리
- JWT 인증 구조에 맞는 인증 흐름 유지